### PR TITLE
Removed unnecessary decode() call.

### DIFF
--- a/btnl_client/protocol/__init__.py
+++ b/btnl_client/protocol/__init__.py
@@ -8,7 +8,7 @@ from .login import (
     LogoutRequest,
 )
 from .market_state import MarketState, MarketStateUpdate
-from .message import Header, Heartbeat, Message, new_message
+from .message import Disconnect, Header, Heartbeat, Message, new_message
 from .order_entry import (
     Ack,
     Close,

--- a/btnl_client/protocol/message.py
+++ b/btnl_client/protocol/message.py
@@ -55,7 +55,7 @@ class Disconnect(MessageBody):
             Disconnect.FORMAT_STR, data
         )
         return Disconnect(
-            DisconnectReason(disconnect_reason.decode()),
+            DisconnectReason(disconnect_reason),
             expected_sequence_id if expected_sequence_id != 0 else None,
             actual_sequence_id if actual_sequence_id != 0 else None,
         )


### PR DESCRIPTION
Removed an unnecessary `.decode()`. Also exported the `Disconnect` type from protocol if that type needs to be used.