### PR TITLE
NoReqReceived login reject rename

### DIFF
--- a/btnl_client/protocol/login.py
+++ b/btnl_client/protocol/login.py
@@ -72,7 +72,7 @@ class LoginAck(MessageBody):
 
 
 class LoginRejectReason(Enum):
-    NotLoggedIn = 0x01
+    NoReqReceived = 0x01
     Unauthorized = 0x02
     AlreadyLoggedIn = 0x03
 

--- a/btnl_client/protocol/message.py
+++ b/btnl_client/protocol/message.py
@@ -27,7 +27,6 @@ class Heartbeat(MessageBody):
 class DisconnectReason(Enum):
     SequenceIdFault = 0x01
     HeartbeatFault = 0x02
-    FailedToLogin = 0x03
     MessagingRateExceeded = 0x04
     ParseFailure = 0x05
 


### PR DESCRIPTION
'NotLoggedIn' is a very confused name for the case where no login
request was received on the server side within 1 s.